### PR TITLE
fix(ci.yml): force unity build version if no found

### DIFF
--- a/templates/steps/ci.yml
+++ b/templates/steps/ci.yml
@@ -20,13 +20,16 @@ steps:
       {
         If (!$setupInstance)
         {
-          Write-Error "No Unity version specified and no Unity installation found."
-          Exit 1
+          Write-Host "No Unity version specified and no Unity installation found - forcing to min supported version of 2018.3.10f1"
+          $version = '2018.3.10f1';
         }
-
-        Write-Host "Using already installed Unity version '$($setupInstance.Version)'."
+        Else
+        {
+          Write-Host "Using already installed Unity version '$($setupInstance.Version)'."
+        }
       }
-      ElseIf ($setupInstance.Version.ToString() -ne $version)
+
+      If ($setupInstance.Version.ToString() -ne $version)
       {
         Write-Host "Installing Unity version '$version'."
         Install-UnitySetupInstance -Installers (Find-UnitySetupInstaller -Version $version -Components "Windows")


### PR DESCRIPTION
If there is no Unity installer present and no Unity version is provided then
the process just fails, and for some reason there seems to be no found
Unity version so let's force it to be the min supported Unity version.