### PR TITLE
fix(ci.yml): wrap version in quotation marks

### DIFF
--- a/templates/steps/ci.yml
+++ b/templates/steps/ci.yml
@@ -21,7 +21,7 @@ steps:
         If (!$setupInstance)
         {
           Write-Host "No Unity version specified and no Unity installation found - forcing to min supported version of 2018.3.10f1"
-          $version = '2018.3.10f1';
+          $version = "2018.3.10f1";
         }
         Else
         {


### PR DESCRIPTION
The version setter should be wrapped in quotation marks `"` and not
apostrophies `'`.