### PR TITLE
fix(ci.yml): check for null setup instance

### DIFF
--- a/templates/steps/ci.yml
+++ b/templates/steps/ci.yml
@@ -21,7 +21,7 @@ steps:
         If (!$setupInstance)
         {
           Write-Host "No Unity version specified and no Unity installation found - forcing to min supported version of 2018.3.10f1"
-          $version = "2018.3.10f1";
+          $version = "2018.3.10f1"
         }
         Else
         {
@@ -29,7 +29,7 @@ steps:
         }
       }
 
-      If ($setupInstance.Version.ToString() -ne $version)
+      If (!$setupInstance -or $setupInstance.Version.ToString() -ne $version)
       {
         Write-Host "Installing Unity version '$version'."
         Install-UnitySetupInstance -Installers (Find-UnitySetupInstaller -Version $version -Components "Windows")


### PR DESCRIPTION
If `$setupInstance` is not found then we must force install
the base version of Unity.